### PR TITLE
Install roave/security-advisories as required by the bartacus bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/symfony": "^3.0",
         "bartacus/bartacus-bundle": "^1.0@dev",
         "sensio/distribution-bundle": "^5.0",
-        "incenteev/composer-parameter-handler": "^2.0"
+        "incenteev/composer-parameter-handler": "^2.0",
+        "roave/security-advisories": "dev-master"
     },
     "scripts": {
         "symfony-scripts": [


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | connects to Bartacus/BartacusBundle#7
| License | GPL-3.0+

#### What's in this PR?

Install `roave/security-advisories` package here to, because of the installation in Bartacus/BartacusBundle#24 this is a must have requirement for every user of the bartacus bundle.