### PR TITLE
Fix missing typo3/sysext symlink in web dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
+            "bin/console bartacus:web-dir:prepare"
         ],
         "post-install-cmd": [
             "@symfony-scripts"


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #7 
| Related issues/PRs | Bartacus/BartacusBundle#40
| License | GPL-3.0+

#### What's in this PR?

Prepares the missing typo3/sysext symlink in web dir on composer install/update
